### PR TITLE
Fix requirements version conflict with MW Core

### DIFF
--- a/Bootstrap.php
+++ b/Bootstrap.php
@@ -48,7 +48,7 @@ call_user_func( function () {
 	/**
 	 * The extension version
 	 */
-	define( 'BS_VERSION', '1.2.3' );
+	define( 'BS_VERSION', '1.3.0' );
 
 	// register the extension
 	$GLOBALS[ 'wgExtensionCredits' ][ 'other' ][ ] = array(

--- a/README.md
+++ b/README.md
@@ -9,17 +9,15 @@ front-end framework to skins and extensions.
 ## Requirements
 
 - PHP 5.3.2 or later
-- MediaWiki 1.22 or later
+- MediaWiki 1.27 or later
 - [Composer][composer]
 
 ## Installation
 
 1. On a command line go to your MediaWiki installation directory
-2. If necessary (on MediaWiki up to 1.23) copy the file `composer.json.example`
-   to `composer.json`
-3. With Composer installed, run
+2. With Composer installed, run
    `composer require "mediawiki/bootstrap:~1.0"`
-4. __Done:__ Navigate to _Special:Version_ on your wiki to verify that the
+3. __Done:__ Navigate to _Special:Version_ on your wiki to verify that the
    extension is successfully installed.
 
 ## Documentation

--- a/composer.json
+++ b/composer.json
@@ -27,8 +27,7 @@
 	},
 	"require"    : {
 		"php"                : ">=5.3.0",
-		"composer/installers": "1.*,>=1.0.1",
-		"oyejorge/less.php"  : "~1.0,>=1.7.0.9,!=1.7.0.13"
+		"composer/installers": "1.*,>=1.0.1"
 	},
 	"autoload"   : {
 		"files": [


### PR DESCRIPTION
MediaWiki Core switched the dependency "oyejorge/less.php" to
"wikimedia/less.php".

Now both libraries are pulled and composer complains about
"Ambiguous class resolution".

Removing the requirement in this extension fixes the problem.

See https://github.com/cmln/mw-bootstrap/issues/8 for details